### PR TITLE
add phuslog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/phuslu/log v1.0.81 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.27.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
+github.com/phuslu/log v1.0.81 h1:07l/g+gde7oD77iCHXst/0iSu40BbcEkvv4pTeQCe+c=
+github.com/phuslu/log v1.0.81/go.mod h1:kzJN3LRifrepxThMjufQwS7S35yFAB+jAV1qgA7eBW4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/globusdigital/logbench/benchmark"
 	"github.com/globusdigital/logbench/logrus"
+	"github.com/globusdigital/logbench/phuslog"
 	"github.com/globusdigital/logbench/zap"
 	"github.com/globusdigital/logbench/zerolog"
 )
@@ -22,6 +23,7 @@ var setups = map[string]benchmark.Setup{
 	"zap":     zap.Setup(),
 	"zerolog": zerolog.Setup(),
 	"logrus":  logrus.Setup(),
+	"phuslog": phuslog.Setup(),
 }
 
 func setupTermSigInterceptor() func() bool {

--- a/phuslog/phuslog.go
+++ b/phuslog/phuslog.go
@@ -1,0 +1,117 @@
+package phuslog
+
+import (
+	"io"
+
+	"github.com/globusdigital/logbench/benchmark"
+	phuslog "github.com/phuslu/log"
+)
+
+func init() {
+}
+
+func newLogger(out io.ReadWriter) phuslog.Logger {
+	// Initialize logger
+	return phuslog.Logger{
+		Level:  phuslog.InfoLevel,
+		Writer: &phuslog.IOWriter{out},
+	}
+}
+
+func newInfo(out io.ReadWriter) (benchmark.FnInfo, error) {
+	l := newLogger(out)
+	return func(msg string) {
+		l.Info().Msg(msg)
+	}, nil
+}
+
+func newInfoFmt(out io.ReadWriter) (benchmark.FnInfoFmt, error) {
+	l := newLogger(out)
+	return func(msg string, data int) {
+		l.Info().Msgf(msg, data)
+	}, nil
+}
+
+func newInfoWithErrorStack(out io.ReadWriter) (
+	benchmark.FnInfoWithErrorStack, error,
+) {
+	l := newLogger(out)
+	return func(msg string, err error) {
+		l.Context = phuslog.NewContext(l.Context[:0]).Err(err).Value()
+		l.Info().Msg(msg)
+	}, nil
+}
+
+func newError(out io.ReadWriter) (benchmark.FnError, error) {
+	l := newLogger(out)
+	return func(msg string) {
+		l.Error().Msg(msg)
+	}, nil
+}
+
+func newInfoWith3(out io.ReadWriter) (benchmark.FnInfoWith3, error) {
+	l := newLogger(out)
+	return func(msg string, fields *benchmark.Fields3) {
+		l.Context = phuslog.NewContext(l.Context[:0]).
+			Str(fields.Name1, fields.Value1).
+			Int(fields.Name2, fields.Value2).
+			Float64(fields.Name3, fields.Value3).
+			Value()
+		l.Info().Msg(msg)
+	}, nil
+}
+
+func newInfoWith10(out io.ReadWriter) (benchmark.FnInfoWith10, error) {
+	l := newLogger(out)
+	return func(msg string, fields *benchmark.Fields10) {
+		l.Context = phuslog.NewContext(l.Context[:0]).
+			Str(fields.Name1, fields.Value1).
+			Str(fields.Name2, fields.Value2).
+			Str(fields.Name3, fields.Value3).
+			Bool(fields.Name4, fields.Value4).
+			Str(fields.Name5, fields.Value5).
+			Int(fields.Name6, fields.Value6).
+			Float64(fields.Name7, fields.Value7).
+			Strs(fields.Name8, fields.Value8).
+			Ints(fields.Name9, fields.Value9).
+			Floats64(fields.Name10, fields.Value10).
+			Value()
+		l.Info().Msg(msg)
+	}, nil
+}
+
+func newInfoWith10Exist(out io.ReadWriter) (
+	benchmark.FnInfoWith10Exist,
+	error,
+) {
+	fields := benchmark.NewFields10()
+	l := newLogger(out)
+	l.Context = phuslog.NewContext(l.Context[:0]).
+		Str(fields.Name1, fields.Value1).
+		Str(fields.Name2, fields.Value2).
+		Str(fields.Name3, fields.Value3).
+		Bool(fields.Name4, fields.Value4).
+		Str(fields.Name5, fields.Value5).
+		Int(fields.Name6, fields.Value6).
+		Float64(fields.Name7, fields.Value7).
+		Strs(fields.Name8, fields.Value8).
+		Ints(fields.Name9, fields.Value9).
+		Floats64(fields.Name10, fields.Value10).
+		Value()
+	return func(msg string) {
+		l.Info().Msg(msg)
+	}, nil
+}
+
+// Setup initializes the phuslog based logger
+func Setup() benchmark.Setup {
+	return benchmark.Setup{
+		Info:               newInfo,
+		InfoFmt:            newInfoFmt,
+		InfoWithErrorStack: newInfoWithErrorStack,
+		Error:              newError,
+		InfoWith3:          newInfoWith3,
+		InfoWith10:         newInfoWith10,
+		InfoWith10Exist:    newInfoWith10Exist,
+	}
+}


### PR DESCRIPTION
phuslog is zerolog alternative logging lib but with some performance improvement. here is my logbench result

zerolog:
```
+---------------+---------------+
| target        | 1,000,000     |
| conc. writers | 8             |
|               |               |
| time total    | 27.638801567s |
| max heap      | 4.9 MB        |
| max heap obj  | 249,229       |
| mem samples   | 12,637        |
| heap inc      | 687           |
| heap obj in   | 694           |
| heap sys      | 7.9 MB        |
| total alloc   | 1.6 GB        |
| mallocs       | 4,005,861     |
| num-gc        | 391           |
| total pause   | 69.510769ms   |
+---------------+---------------+
+---------+-----------------------+--------------+-----------+-----------+
| LOGGER  |       OPERATION       |  TIME TOTAL  | TIME AVG  |  WRITTEN  |
+---------+-----------------------+--------------+-----------+-----------+
| zerolog | info                  | 2.858838243s | 2.858µs   | 1,000,000 |
| zerolog | info_fmt              | 3.42490636s  | 3.424µs   | 1,000,000 |
| zerolog | info_with_error_stack | 3.61739477s  | 3.617µs   | 1,000,000 |
| zerolog | info_with_3           | 3.916054559s | 3.916µs   | 1,000,000 |
| zerolog | info_with_10          | 6.717420074s | 6.717µs   | 1,000,000 |
| zerolog | info_with_10_exist    | 4.053668411s | 4.053µs   | 1,000,000 |
| zerolog | error                 | 3.050369184s | 3.05µs    | 1,000,000 |
+---------+-----------------------+--------------+-----------+-----------+
```

phuslog
```
+---------------+---------------+
| target        | 1,000,000     |
| conc. writers | 8             |
|               |               |
| time total    | 19.433652422s |
| max heap      | 4.2 MB        |
| max heap obj  | 84,249        |
| mem samples   | 9,598         |
| heap inc      | 431           |
| heap obj in   | 435           |
| heap sys      | 7.9 MB        |
| total alloc   | 48 MB         |
| mallocs       | 1,002,045     |
| num-gc        | 12            |
| total pause   | 3.260997ms    |
+---------------+---------------+
+---------+-----------------------+--------------+-----------+-----------+
| LOGGER  |       OPERATION       |  TIME TOTAL  | TIME AVG  |  WRITTEN  |
+---------+-----------------------+--------------+-----------+-----------+
| phuslog | info                  | 2.26169846s  | 2.261µs   | 1,000,000 |
| phuslog | info_fmt              | 2.617029886s | 2.617µs   | 1,000,000 |
| phuslog | info_with_error_stack | 2.624548288s | 2.624µs   | 1,000,000 |
| phuslog | info_with_3           | 2.683464484s | 2.683µs   | 1,000,000 |
| phuslog | info_with_10          | 4.290994785s | 4.29µs    | 1,000,000 |
| phuslog | info_with_10_exist    | 2.616568268s | 2.616µs   | 1,000,000 |
| phuslog | error                 | 2.339183257s | 2.339µs   | 1,000,000 |
+---------+-----------------------+--------------+-----------+-----------+
```